### PR TITLE
data in kg is not indexed

### DIFF
--- a/digsandpaper/elasticsearch_mapping/generate.py
+++ b/digsandpaper/elasticsearch_mapping/generate.py
@@ -42,7 +42,7 @@ def generate(default_mapping, semantic_types,
     default_prov_props = {"properties": default_prov_ev_props}
     default_knowledge_graph_props = {"key": {"type": "string", "index": "not_analyzed"},
                                      "provenance": default_prov_props,
-                                     "value": {"type": "string"}}
+                                     "value": {"type": "string"}, "data": {"enabled": False}}
     kg_to_copy = {"properties": default_knowledge_graph_props}
     knowledge_graph = {}
     default_mapping["mappings"]["ads"]["properties"]["knowledge_graph"] = {"properties": knowledge_graph}


### PR DESCRIPTION
We have a new field in knowledge_graph.<semantic_type>[] `data` which is any arbitrary object. This pull request will ensure that `data` is never indexed.
Or thats what I think this pull request does. Any other place to change it @jasonslepicka ?